### PR TITLE
Invalidate password history when applicable policies change

### DIFF
--- a/password_policy.module
+++ b/password_policy.module
@@ -731,7 +731,7 @@ function password_policy_user_insert($account) {
 /**
  * Implements hook_user_update().
  *
- * Store new password hashes in history when the password actually changes.
+ * Stores new password hashes and invalidates history on role change.
  */
 function password_policy_user_update($account) {
   if (empty($account->uid)) {
@@ -741,6 +741,26 @@ function password_policy_user_update($account) {
   // If there is an original account and the hash changed, record it.
   if (!empty($account->original) && isset($account->original->pass) && isset($account->pass) && $account->pass !== $account->original->pass) {
     _password_policy_store_password($account->uid, $account->pass);
+  }
+
+  // Invalidate password history when applicable policies change. Constraints
+  // are checked only at password-set time, so a newly-applicable policy would
+  // never apply to an existing password without this.
+  if (!empty($account->original)) {
+    $old = array_map(function ($policy) {
+      return $policy->name;
+    }, PasswordPolicy::matchedPolicies($account->original));
+    $new = array_map(function ($policy) {
+      return $policy->name;
+    }, PasswordPolicy::matchedPolicies($account));
+    sort($old);
+    sort($new);
+    if ($old !== $new) {
+      db_update('password_policy_history')
+        ->fields(array('created' => 1))
+        ->condition('uid', $account->uid)
+        ->execute();
+    }
   }
 }
 


### PR DESCRIPTION
Resolves #7.

On role change, compare `PasswordPolicy::matchedPolicies()` for the original vs current account. If the set of applicable policies differs, mark every row in `password_policy_history` as old so the expire constraint prompts on next page load.

Comparing the matched-policy set (rather than the raw role set) avoids prompting when the role change has no effect on policy coverage — permissionless role adds, swaps between roles with identical policies, and role removals where the lost role's policies still apply via another role.

Implemented in `hook_user_update` rather than a form submit handler so it also catches programmatic role changes from Rules, migrations, SSO provisioning, drush, or any other `user_save()` caller — see issue #7 for the cross-version comparison.

Residual tradeoff: a role change that swaps a stricter policy for a looser one of the same shape (e.g., `char_count >= 20` → `char_count >= 8`) will still prompt. Re-checking the existing password against the new constraints isn't possible without cleartext. Accepted — under-prompting on a stricter change is a security gap; over-prompting on a looser one is only an annoyance.